### PR TITLE
updating git clone address

### DIFF
--- a/sections/preparing.md
+++ b/sections/preparing.md
@@ -15,7 +15,7 @@ If you already have a projects folder, you can skip this step.
 Next, clone the text analysis session repository into your projects folder by entering this command:
 
 ```bash
-git clone git@github.com:DHRI-Curriculum/text-analysis.git ~/Desktop/projects/text-analysis
+git clone https://github.com/DHRI-Curriculum/text-analysis.git ~/Desktop/projects/text-analysis
 ```
 
 Then move to the new directory:


### PR DESCRIPTION
previous git clone address git@github.com:DHRI-Curriculum/text-analysis.git gives an error: 

fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.

Solution is to use https://github.com/ as prefix